### PR TITLE
`ISS-48`: Allowing evaluation of the posterior distribution.

### DIFF
--- a/tinyDA/posterior.py
+++ b/tinyDA/posterior.py
@@ -127,9 +127,9 @@ class Posterior:
             The posterior density evaluated at given model parameters.
         """
 
-        qoi = self.create_link(parameters).posterior
+        posterior_value = self.create_link(parameters).posterior
 
-        return qoi
+        return posterior_value
 
 
 class LinkFactory(Posterior):

--- a/tinyDA/posterior.py
+++ b/tinyDA/posterior.py
@@ -5,8 +5,8 @@ from numpy.linalg import inv
 
 from .link import Link
 
-class Posterior:
 
+class Posterior:
     """Posterior connects the prior, likelihood and model to produce MCMC
     samples (Links). The create_link-method calls evaluate_model, which is the
     key method in this class. It must be overwritten through inheritance to
@@ -114,6 +114,24 @@ class Posterior:
             link.parameters, link.prior, link.model_output, likelihood, link.qoi
         )
 
+    def posterior_eval(self, parameters):
+        """
+        Parameters
+        ----------
+        parameters : numpy.ndarray
+            A numpy array of model parameters.
+
+        Returns
+        ----------
+        float
+            The posterior density evaluated at given model parameters.
+        """
+
+        qoi = self.create_link(parameters).posterior
+
+        return qoi
+
+
 class LinkFactory(Posterior):
     def __init__(self, prior, likelihood):
 
@@ -123,6 +141,7 @@ class LinkFactory(Posterior):
         )
 
         super().__init__(prior, likelihood)
+
 
 class BlackBoxLinkFactory(Posterior):
     def __init__(self, model, prior, likelihood, get_qoi=False):

--- a/tinyDA/posterior.py
+++ b/tinyDA/posterior.py
@@ -60,6 +60,21 @@ class Posterior:
         else:
             self.model = model
 
+    def __call__(self, parameters):
+        """
+        Parameters
+        ----------
+        parameters : numpy.ndarray
+            A numpy array of model parameters.
+
+        Returns
+        ----------
+        numpy.ndarray
+            The unnormalised posterior evaluated at the given parameters.
+        """
+
+        return self.logpdf(parameters)
+
     def create_link(self, parameters):
         """
         Parameters
@@ -114,7 +129,7 @@ class Posterior:
             link.parameters, link.prior, link.model_output, likelihood, link.qoi
         )
 
-    def posterior_eval(self, parameters):
+    def logpdf(self, parameters):
         """
         Parameters
         ----------
@@ -124,7 +139,7 @@ class Posterior:
         Returns
         ----------
         float
-            The posterior density evaluated at given model parameters.
+            The unnormalised posterior density evaluated at given model parameters.
         """
 
         posterior_value = self.create_link(parameters).posterior

--- a/tinyDA/proposal.py
+++ b/tinyDA/proposal.py
@@ -972,9 +972,7 @@ class MALA(Proposal):
 
     def _compute_gradient_approx(self, link):
         # aproximate the gradient of the log-posterior using finite differences.
-        grad_log_posterior = approx_fprime(
-            link.parameters, lambda x: self.posterior.logpdf(x)
-        )
+        grad_log_posterior = approx_fprime(link.parameters, self.posterior.logpdf)
         return grad_log_posterior
 
 

--- a/tinyDA/proposal.py
+++ b/tinyDA/proposal.py
@@ -41,7 +41,6 @@ class Proposal:
 
 
 class IndependenceSampler(Proposal):
-
     """Independence sampler using a proposal distribution q(x).
 
     Attributes
@@ -109,7 +108,6 @@ class IndependenceSampler(Proposal):
 
 
 class GaussianRandomWalk(Proposal):
-
     """Standard Random Walk Metropolis Hastings proposal.
 
     Attributes
@@ -239,7 +237,6 @@ class GaussianRandomWalk(Proposal):
 
 
 class CrankNicolson(GaussianRandomWalk):
-
     """Preconditioned Crank Nicolson proposal. To use this proposal, the prior
     must be of the type scipy.stats.multivariate_normal.
 
@@ -351,7 +348,6 @@ class CrankNicolson(GaussianRandomWalk):
 
 
 class AdaptiveMetropolis(GaussianRandomWalk):
-
     """Adaptive Metropolis proposal, according to Haario et al. (2001)
 
     Attributes
@@ -495,7 +491,6 @@ class AdaptiveMetropolis(GaussianRandomWalk):
 
 
 class OperatorWeightedCrankNicolson(CrankNicolson):
-
     """Operator-weighted preconditioned Crank-Nicolson proposal (Law 2014).
 
     Attributes
@@ -589,7 +584,6 @@ class OperatorWeightedCrankNicolson(CrankNicolson):
 
 
 class DREAMZ(GaussianRandomWalk):
-
     """Dream(Z) proposal, similar to the DREAM(ZS) algorithm (see e.g. Vrugt
     2016).
 
@@ -979,7 +973,7 @@ class MALA(Proposal):
     def _compute_gradient_approx(self, link):
         # aproximate the gradient of the log-posterior using finite differences.
         grad_log_posterior = approx_fprime(
-            link.parameters, lambda x: self.posterior.create_link(x).posterior
+            link.parameters, lambda x: self.posterior.logpdf(x)
         )
         return grad_log_posterior
 
@@ -1104,7 +1098,6 @@ class KernelMALA(MALA):
 
 
 class PoissonPointProposal(GaussianRandomWalk):
-
     """PoissonPointProposal can be seen as a special case of Reversible
     Jump MCMC. It is used to make moves for a PoissonPointProcess prior.
 
@@ -1257,7 +1250,6 @@ class PoissonPointProposal(GaussianRandomWalk):
 
 
 class MLDA(Proposal):
-
     """MLDAChain is a Multilevel Delayed Acceptance sampler. It takes a list of
     posteriors of increasing level as input, as well as a proposal, which
     applies to the coarsest level only.


### PR DESCRIPTION
This PR addresses #48 . A new method `logpdf` has been added to the `Posterior` class with which the unnormalised posterior density can be evaluated for a given set of model parameters.