### PR TITLE
Typechecking

### DIFF
--- a/tinyDA/chain.py
+++ b/tinyDA/chain.py
@@ -485,7 +485,8 @@ class DAChain:
             self.posterior_coarse.likelihood.set_bias(
                 self.model_diff, self.bias.get_sigma()
             )
-
+        else:
+            raise NameError("Adaptive error model can only be state-dependent, state-independent or None.")
         self.chain_coarse[-1] = self.posterior_coarse.update_link(self.chain_coarse[-1])
 
 
@@ -622,7 +623,8 @@ class MLDAChain:
             # it may not be ergodic.
             elif self.adaptive_error_model == "state-dependent":
                 pass
-
+            else:
+                raise NameError("Adaptive error model can only be state-dependent, state-independent or None.")
             # update the first coarser link with the adaptive error model.
             self.proposal.chain[-1] = self.proposal.posterior.update_link(
                 self.proposal.chain[-1]

--- a/tinyDA/chain.py
+++ b/tinyDA/chain.py
@@ -717,6 +717,8 @@ class MLDAChain:
                 # state-dependent error model has not been implemented.
                 elif self.adaptive_error_model == "state-dependent":
                     pass
+                else:
+                    raise NameError("Adaptive error model can only be state-dependent, state-independent or None.")
 
                 # update the latest coarser link with the adaptive error model.
                 self.proposal.chain[-1] = self.proposal.posterior.update_link(

--- a/tinyDA/chain.py
+++ b/tinyDA/chain.py
@@ -624,7 +624,7 @@ class MLDAChain:
             elif self.adaptive_error_model == "state-dependent":
                 pass
             else:
-                raise NameError("Adaptive error model can only be state-dependent, state-independent or None.")
+                raise ValueError("Adaptive error model can only be state-dependent, state-independent or None.")
             # update the first coarser link with the adaptive error model.
             self.proposal.chain[-1] = self.proposal.posterior.update_link(
                 self.proposal.chain[-1]

--- a/tinyDA/distributions.py
+++ b/tinyDA/distributions.py
@@ -207,6 +207,18 @@ def GaussianLogLike(data, covariance):
         IsotropicGaussianLogLike, depending on the structure of the
         giver covariance matrix.
     """
+
+    # check if covariance operator is a square numpy array.
+    if not isinstance(covariance, np.ndarray):
+        raise TypeError("Covariance must be a 2-D numpy array.")
+    elif covariance.ndim == 1:
+        raise TypeError("Covariance must be a 2-D numpy array.")
+    elif covariance.ndim >= 2:
+        if not covariance.shape[0] == data.shape[0]:
+            raise ValueError("Dimensions of data and covariance do not match.")
+    elif not covariance.shape[0] == covariance.shape[1]:
+        raise ValueError("Covariance must be an NxN array.")
+
     if np.count_nonzero(covariance - np.diag(np.diag(covariance))) == 0:
         if np.all(np.diag(covariance) == covariance[0,0]):
             return IsotropicGaussianLogLike(data, covariance[0,0])
@@ -277,6 +289,12 @@ class DiagonalGaussianLogLike(DefaultGaussianLogLike):
         # set the data and covariance as attributes
         self.data = data
         self.cov = np.diag(covariance)
+
+        if not isinstance(covariance, np.ndarray):
+            raise TypeError("Covariance must be a numpy array.")
+        elif covariance.ndim == 1:
+            if not covariance.shape[0] == data.shape[0]:
+                raise ValueError("Dimensions of data and covariance do not match.")
 
     def loglike(self, x):
         # compute the unnormalised likelihood.

--- a/tinyDA/distributions.py
+++ b/tinyDA/distributions.py
@@ -353,6 +353,16 @@ class AdaptiveGaussianLogLike(DefaultGaussianLogLike):
         cov : numpy.ndarray
             The covariance of the Gaussian likelihood function.
         """
+        # check if covariance operator is a square numpy array.
+        if not isinstance(covariance, np.ndarray):
+            raise TypeError("Covariance must be a 2-D numpy array.")
+        elif covariance.ndim == 1:
+            raise TypeError("Covariance must be a 2-D numpy array.")
+        elif covariance.ndim >= 2:
+            if not covariance.shape[0] == data.shape[0]:
+                raise ValueError("Dimensions of data and covariance do not match.")
+        elif not covariance.shape[0] == covariance.shape[1]:
+            raise ValueError("Covariance must be an NxN array.")
 
         super().__init__(data, covariance)
 

--- a/tinyDA/posterior.py
+++ b/tinyDA/posterior.py
@@ -94,6 +94,10 @@ class Posterior:
         # get the model output and the qoi.
         model_output = self.model(parameters)
 
+        # check that model output is numpy array
+        if not isinstance(model_output, np.ndarray):
+            raise TypeError("Model output must be numpy array!")
+
         # extract model output and qoi.
         if isinstance(model_output, tuple):
             model_output, qoi = model_output


### PR DESCRIPTION
Includes small adjustments to specific problems that I ran into some months ago, related to data types.
- model output must be a numpy array (instead of a list)
- number of dimensions of the covariance matrix in GaussianLogLike and AdaptiveGaussianLogLike must be 2, and match dimensions of data
- helpful error output if adaptive_error_model is specified wrong (i.e. because of a typo)